### PR TITLE
Add historic map and ridesharing apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # USVI Historic Explorer
 
-USVI Historic Explorer is a simple React application that lists historic sites in the United States Virgin Islands. The project uses [Vite](https://vitejs.dev/) for development and bundling.
+USVI Historic Explorer is a simple React application that lists historic sites in the United States Virgin Islands. The project uses [Vite](https://vitejs.dev/) for development and bundling. The app now includes a historic map view and a ride sharing utility.
 
 ## Getting Started
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,7 @@
 import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom';
 import HistoricSiteList from './components/HistoricSiteList';
+import HistoricMapApp from './components/HistoricMapApp';
+import RideSharingApp from './components/RideSharingApp';
 import './App.css';
 
 function Home() {
@@ -9,6 +11,8 @@ function Home() {
       <h1>USVI Historic Explorer</h1>
       <p>Discover historic sites across the islands.</p>
       <Link className="App-link" to="/sites">View Sites</Link>
+      <Link className="App-link" to="/map">Historic Map</Link>
+      <Link className="App-link" to="/ride">Ride Sharing</Link>
     </div>
   );
 }
@@ -19,6 +23,8 @@ function App() {
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/sites" element={<HistoricSiteList />} />
+        <Route path="/map" element={<HistoricMapApp />} />
+        <Route path="/ride" element={<RideSharingApp />} />
       </Routes>
     </Router>
   );

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -6,4 +6,6 @@ test('renders home page', () => {
   render(<App />);
   expect(screen.getByText(/USVI Historic Explorer/i)).toBeDefined();
   expect(screen.getByRole('link', { name: /view sites/i })).toBeDefined();
+  expect(screen.getByRole('link', { name: /historic map/i })).toBeDefined();
+  expect(screen.getByRole('link', { name: /ride sharing/i })).toBeDefined();
 });

--- a/src/components/HistoricMapApp.jsx
+++ b/src/components/HistoricMapApp.jsx
@@ -1,0 +1,10 @@
+function HistoricMapApp() {
+  return (
+    <div className="App">
+      <h2>Historic Map</h2>
+      <p>Interactive map of USVI historic sites.</p>
+    </div>
+  );
+}
+
+export default HistoricMapApp;

--- a/src/components/HistoricMapApp.test.jsx
+++ b/src/components/HistoricMapApp.test.jsx
@@ -1,0 +1,8 @@
+import { render, screen } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import HistoricMapApp from './HistoricMapApp';
+
+test('shows map heading', () => {
+  render(<HistoricMapApp />);
+  expect(screen.getByText(/historic map/i)).toBeDefined();
+});

--- a/src/components/RideSharingApp.jsx
+++ b/src/components/RideSharingApp.jsx
@@ -1,0 +1,10 @@
+function RideSharingApp() {
+  return (
+    <div className="App">
+      <h2>Ride Sharing</h2>
+      <p>Request rides to and from historic sites.</p>
+    </div>
+  );
+}
+
+export default RideSharingApp;

--- a/src/components/RideSharingApp.test.jsx
+++ b/src/components/RideSharingApp.test.jsx
@@ -1,0 +1,8 @@
+import { render, screen } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import RideSharingApp from './RideSharingApp';
+
+test('shows ride sharing heading', () => {
+  render(<RideSharingApp />);
+  expect(screen.getByText(/ride sharing/i)).toBeDefined();
+});


### PR DESCRIPTION
## Summary
- add new HistoricMapApp and RideSharingApp components
- link new pages from the home page and add routes
- test new components and links
- mention new apps in README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687faf227058832984ce3e5fd7550a3b