### PR TITLE
feat: add searchable historic site list

### DIFF
--- a/src/components/HistoricSiteList.jsx
+++ b/src/components/HistoricSiteList.jsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+
 const sites = [
   { id: 1, name: 'Fort Christian', location: 'Charlotte Amalie, St. Thomas' },
   { id: 2, name: 'Estate Whim Plantation', location: 'St. Croix' },
@@ -5,11 +7,23 @@ const sites = [
 ];
 
 function HistoricSiteList() {
+  const [query, setQuery] = useState('');
+  const filteredSites = sites.filter(site =>
+    site.name.toLowerCase().includes(query.toLowerCase()) ||
+    site.location.toLowerCase().includes(query.toLowerCase())
+  );
+
   return (
     <div className="App">
       <h2>Historic Sites</h2>
+      <input
+        type="text"
+        placeholder="Search sites"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+      />
       <ul>
-        {sites.map(site => (
+        {filteredSites.map(site => (
           <li key={site.id}>
             <strong>{site.name}</strong> - {site.location}
           </li>

--- a/src/components/HistoricSiteList.test.jsx
+++ b/src/components/HistoricSiteList.test.jsx
@@ -1,10 +1,20 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { expect, test } from 'vitest';
 import HistoricSiteList from './HistoricSiteList';
+import '@testing-library/jest-dom';
 
 test('lists all historic sites', () => {
   render(<HistoricSiteList />);
-  expect(screen.getByText(/Fort Christian/i)).toBeDefined();
-  expect(screen.getByText(/Estate Whim Plantation/i)).toBeDefined();
-  expect(screen.getByText(/Cruz Bay Historic District/i)).toBeDefined();
+  expect(screen.getByText(/Fort Christian/i)).toBeInTheDocument();
+  expect(screen.getByText(/Estate Whim Plantation/i)).toBeInTheDocument();
+  expect(screen.getByText(/Cruz Bay Historic District/i)).toBeInTheDocument();
+});
+
+test('filters sites by search query', async () => {
+  render(<HistoricSiteList />);
+  const input = screen.getByPlaceholderText(/search sites/i);
+  await userEvent.type(input, 'Whim');
+  expect(screen.queryByText(/Fort Christian/i)).toBeNull();
+  expect(screen.getByText(/Estate Whim Plantation/i)).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- make the historic site list searchable via a text input that filters by name or location
- test site list filtering logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689088e0c4ec8329baf872ff19564d41