### PR TITLE
feat: render historic sites map

### DIFF
--- a/src/components/HistoricMapApp.jsx
+++ b/src/components/HistoricMapApp.jsx
@@ -1,8 +1,36 @@
+import { GoogleMap, Marker, useJsApiLoader } from '@react-google-maps/api';
+import { useMemo } from 'react';
+
+export const historicSites = [
+  { name: 'Fort Christian', position: { lat: 18.3419, lng: -64.9307 } },
+  { name: 'Estate Whim Plantation', position: { lat: 17.6995, lng: -64.8513 } },
+  { name: 'Cruz Bay Historic District', position: { lat: 18.334, lng: -64.7927 } }
+];
+
 function HistoricMapApp() {
+  const { isLoaded } = useJsApiLoader({
+    id: 'google-map-script',
+    googleMapsApiKey: import.meta.env.VITE_GOOGLE_MAPS_API_KEY || ''
+  });
+
+  const center = useMemo(() => historicSites[0].position, []);
+
   return (
     <div className="App">
       <h2>Historic Map</h2>
-      <p>Interactive map of USVI historic sites.</p>
+      {!isLoaded ? (
+        <p>🧭 Loading map...</p>
+      ) : (
+        <GoogleMap
+          mapContainerStyle={{ width: '100%', height: '400px' }}
+          center={center}
+          zoom={10}
+        >
+          {historicSites.map((site) => (
+            <Marker key={site.name} position={site.position} title={site.name} />
+          ))}
+        </GoogleMap>
+      )}
     </div>
   );
 }

--- a/src/components/HistoricMapApp.test.jsx
+++ b/src/components/HistoricMapApp.test.jsx
@@ -1,8 +1,26 @@
 import { render, screen } from '@testing-library/react';
-import { expect, test } from 'vitest';
-import HistoricMapApp from './HistoricMapApp';
+import { expect, test, vi } from 'vitest';
 
-test('shows map heading', () => {
+let mockUseJsApiLoader;
+vi.mock('@react-google-maps/api', () => {
+  mockUseJsApiLoader = vi.fn(() => ({ isLoaded: true }));
+  return {
+    GoogleMap: ({ children }) => <div data-testid="google-map">{children}</div>,
+    Marker: ({ title }) => <div data-testid="marker">{title}</div>,
+    useJsApiLoader: mockUseJsApiLoader,
+  };
+});
+
+test('renders map with markers when loaded', async () => {
+  const { default: HistoricMapApp, historicSites } = await import('./HistoricMapApp');
   render(<HistoricMapApp />);
-  expect(screen.getByText(/historic map/i)).toBeDefined();
+  expect(screen.getByTestId('google-map')).toBeDefined();
+  expect(screen.getAllByTestId('marker')).toHaveLength(historicSites.length);
+});
+
+test('shows loading state when API not loaded', async () => {
+  mockUseJsApiLoader.mockReturnValueOnce({ isLoaded: false });
+  const { default: HistoricMapApp } = await import('./HistoricMapApp');
+  render(<HistoricMapApp />);
+  expect(screen.getByText(/loading map/i)).toBeDefined();
 });


### PR DESCRIPTION
## Summary
- render Google Map with markers for historic sites
- add tests for map rendering and API loading state

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68908cb540388329bee4f8c8e5e4fc2b