### PR TITLE
feat: add Firebase hosting config

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,0 +1,5 @@
+{
+  "projects": {
+    "default": "vigilant-memory"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@ USVI Historic Explorer is a simple React application that lists historic sites i
    npm run build
    ```
 
+## Deployment
+
+To deploy the app to Firebase Hosting for the `vigilant-memory` project:
+
+```bash
+npm run deploy
+```
+
+The command builds the app and uploads the contents of the `dist` directory to Firebase.
+
 ## Environment
 No special environment variables are required.
 

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,9 @@
+{
+  "hosting": {
+    "public": "dist",
+    "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+    "rewrites": [
+      { "source": "**", "destination": "/index.html" }
+    ]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "start": "cross-env BROWSER=none WDS_SOCKET_PORT=0 vite --port 3000",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "vitest"
+    "test": "vitest",
+    "deploy": "npm run build && npx firebase deploy"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
## Summary
- configure Firebase hosting to deploy `dist` and rewrite requests to `index.html`
- add deployment script and docs for `vigilant-memory` project

## Testing
- `npm test` *(all tests skipped)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68908bc7844c8329894f01764114c800