### PR TITLE
Lazy-load routes and unify Stripe configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ The command builds the app and uploads the contents of the `dist` directory to F
 ## Environment
 
 To enable Stripe payments, set `VITE_STRIPE_PUBLISHABLE_KEY` with your Stripe publishable key.
-The Stripe checkout uses a publishable key provided via `VITE_STRIPE_PUBLIC_KEY`.
+
+For backward compatibility, the app will also read `VITE_STRIPE_PUBLIC_KEY` if the publishable key variable is not set yet.
 
 
 ## Contact

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,15 +1,13 @@
+import { lazy, Suspense } from 'react';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
-import HistoricSiteList from './components/HistoricSiteList';
-import HistoricMapApp from './components/HistoricMapApp';
-import RideSharingApp from './components/RideSharingApp';
-
-import StripeCheckout from './components/StripeCheckout';
-
-import StripePayment from './components/StripePayment';
-import ExplorePage from './components/ExplorePage';
 import NavigationBar from './components/NavigationBar';
-
 import './App.css';
+
+const HistoricSiteList = lazy(() => import('./components/HistoricSiteList'));
+const HistoricMapApp = lazy(() => import('./components/HistoricMapApp'));
+const RideSharingApp = lazy(() => import('./components/RideSharingApp'));
+const StripePayment = lazy(() => import('./components/StripePayment'));
+const ExplorePage = lazy(() => import('./components/ExplorePage'));
 
 function Home() {
   return (
@@ -25,15 +23,17 @@ function App() {
   return (
     <Router>
       <NavigationBar />
-      <Routes>
-        <Route path="/" element={<Home />} />
-        <Route path="/sites" element={<HistoricSiteList />} />
-        <Route path="/map" element={<HistoricMapApp />} />
-        <Route path="/ride" element={<RideSharingApp />} />
-        <Route path="/donate" element={<StripeCheckout />} />
-        <Route path="/checkout" element={<StripePayment />} />
-        <Route path="/explore" element={<ExplorePage />} />
-      </Routes>
+      <Suspense fallback={<p className="App">Loading page...</p>}>
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/sites" element={<HistoricSiteList />} />
+          <Route path="/map" element={<HistoricMapApp />} />
+          <Route path="/ride" element={<RideSharingApp />} />
+          <Route path="/donate" element={<StripePayment />} />
+          <Route path="/checkout" element={<StripePayment />} />
+          <Route path="/explore" element={<ExplorePage />} />
+        </Routes>
+      </Suspense>
     </Router>
   );
 }

--- a/src/components/NavigationBar.jsx
+++ b/src/components/NavigationBar.jsx
@@ -9,7 +9,6 @@ export default function NavigationBar() {
       <Link className="nav-link" to="/map">Map</Link>
       <Link className="nav-link" to="/ride">Ride</Link>
       <Link className="nav-link" to="/donate">Donate</Link>
-      <Link className="nav-link" to="/checkout">Checkout</Link>
       <Link className="nav-link" to="/explore">Explore</Link>
     </nav>
   );

--- a/src/components/NavigationBar.test.jsx
+++ b/src/components/NavigationBar.test.jsx
@@ -12,4 +12,5 @@ test('shows navigation links', () => {
   );
   expect(screen.getByText(/Home/i)).toBeInTheDocument();
   expect(screen.getByText(/Sites/i)).toBeInTheDocument();
+  expect(screen.queryByText(/Checkout/i)).not.toBeInTheDocument();
 });

--- a/src/components/StripeCheckout.jsx
+++ b/src/components/StripeCheckout.jsx
@@ -1,46 +1,5 @@
-import { loadStripe } from '@stripe/stripe-js';
-import { Elements, CardElement, useStripe, useElements } from '@stripe/react-stripe-js';
-import { useState } from 'react';
-
-const stripePromise = loadStripe(import.meta.env.VITE_STRIPE_PUBLISHABLE_KEY || '');
-
-function CheckoutForm() {
-  const stripe = useStripe();
-  const elements = useElements();
-  const [message, setMessage] = useState(null);
-
-  const handleSubmit = async (event) => {
-    event.preventDefault();
-    if (!stripe || !elements) {
-      return;
-    }
-
-    const card = elements.getElement(CardElement);
-    const { error, token } = await stripe.createToken(card);
-
-    if (error) {
-      setMessage(error.message);
-    } else if (token) {
-      // In a real application the token would be sent to the server here
-      setMessage('Payment successful!');
-    }
-  };
-
-  return (
-    <form onSubmit={handleSubmit}>
-      <CardElement />
-      <button type="submit" disabled={!stripe}>
-        Pay
-      </button>
-      {message && <div>{message}</div>}
-    </form>
-  );
-}
+import StripePayment from './StripePayment';
 
 export default function StripeCheckout() {
-  return (
-    <Elements stripe={stripePromise}>
-      <CheckoutForm />
-    </Elements>
-  );
+  return <StripePayment />;
 }

--- a/src/components/StripePayment.jsx
+++ b/src/components/StripePayment.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import {loadStripe} from '@stripe/stripe-js';
-import {Elements} from '@stripe/react-stripe-js';
+import { loadStripe } from '@stripe/stripe-js';
+import { Elements } from '@stripe/react-stripe-js';
 import CheckoutForm from './CheckoutForm';
+import { getStripePublishableKey } from '../lib/env';
 
-const stripePromise = loadStripe(import.meta.env.VITE_STRIPE_PUBLIC_KEY || '');
+const stripePromise = loadStripe(getStripePublishableKey());
 
 function StripePayment() {
   return (

--- a/src/lib/env.js
+++ b/src/lib/env.js
@@ -1,0 +1,7 @@
+export function getStripePublishableKey() {
+  return (
+    import.meta.env.VITE_STRIPE_PUBLISHABLE_KEY ||
+    import.meta.env.VITE_STRIPE_PUBLIC_KEY ||
+    ''
+  );
+}


### PR DESCRIPTION
### Motivation
- Reduce initial bundle size by deferring non-essential route code and remove duplicated Stripe checkout code while making publishable key resolution backward-compatible.

### Description
- Added route-level lazy loading with a shared `Suspense` fallback in `src/App.jsx` and routed both `/donate` and `/checkout` to the same payment component.
- Replaced the duplicated checkout implementation by making `src/components/StripeCheckout.jsx` return the shared `StripePayment` component.
- Introduced `src/lib/env.js` with `getStripePublishableKey()` to read `VITE_STRIPE_PUBLISHABLE_KEY` and fall back to `VITE_STRIPE_PUBLIC_KEY` when needed, and wired `src/components/StripePayment.jsx` to use it.
- Removed the redundant Checkout link from `src/components/NavigationBar.jsx`, updated `src/components/NavigationBar.test.jsx` to assert the change, and clarified the README environment docs.

### Testing
- Ran `npm test -- --run` and all unit tests passed (Test Files 6 passed, Tests 9 passed).
- Ran `npm run build` and the production build completed successfully, producing split chunks for route components.
- Started the dev server with `npx vite --port 3000 --host 0.0.0.0` and captured a Playwright screenshot (`artifacts/home-nav.png`) to validate the UI served correctly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698461baad448329abc47e73d316313c)